### PR TITLE
Adding export of dis.StringConversion for external use

### DIFF
--- a/dis6.js
+++ b/dis6.js
@@ -926,6 +926,7 @@ dis.StringConversion.prototype.DisMarkingToString = function(disMarking)
 if (typeof exports === "undefined")
    exports = {};
 
+exports.StringConversion = dis.StringConversion;
 exports.RangeCoordinates = dis.RangeCoordinates;
 exports.InputStream = dis.InputStream;
 exports.OutputStream = dis.OutputStream;

--- a/dis7.js
+++ b/dis7.js
@@ -926,6 +926,7 @@ dis.StringConversion.prototype.DisMarkingToString = function(disMarking)
 if (typeof exports === "undefined")
    exports = {};
 
+exports.StringConversion = dis.StringConversion;
 exports.RangeCoordinates = dis.RangeCoordinates;
 exports.InputStream = dis.InputStream;
 exports.OutputStream = dis.OutputStream;


### PR DESCRIPTION
Using `dis.StringConversion` methods in a nodejs environment caused an error without the exports statement. 

Please let me know if you have other suggestions or feedback on this. Thanks