### PR TITLE
Change SignalPdu and IntercomPdu signal type to unsigned int

### DIFF
--- a/src/dis/SignalPdu.js
+++ b/src/dis/SignalPdu.js
@@ -83,7 +83,7 @@ dis.SignalPdu = function()
 	try {
 	       for(var idx = 0; idx < (this.dataLength / 8); idx++)
 	       {
-		   var anX = new dis.Chunk(1);
+		   var anX = new dis.Chunk(1, false);
 		   anX.initFromBinary(inputStream);
 		   this.data.push(anX);
 	       }

--- a/src/dis7/IntercomSignalPdu.js
+++ b/src/dis7/IntercomSignalPdu.js
@@ -86,7 +86,7 @@ dis.IntercomSignalPdu = function()
        this.samples = inputStream.readUShort();
        for(var idx = 0; idx < this.dataLength; idx++)
        {
-           var anX = new dis.Chunk(1);
+           var anX = new dis.Chunk(1, false);
            anX.initFromBinary(inputStream);
            this.data.push(anX);
        }

--- a/src/dis7/SignalPdu.js
+++ b/src/dis7/SignalPdu.js
@@ -78,7 +78,7 @@ dis.SignalPdu = function()
        this.samples = inputStream.readShort();
        for(var idx = 0; idx < this.dataLength; idx++)
        {
-           var anX = new dis.Chunk(1);
+           var anX = new dis.Chunk(1, false);
            anX.initFromBinary(inputStream);
            this.data.push(anX);
        }

--- a/src/disSupporting/Chunk.js
+++ b/src/disSupporting/Chunk.js
@@ -8,19 +8,20 @@ if (typeof exports === "undefined")
 // Replaces (n)ByteChunk functions
 // chunkSize: specify the size of the chunk, ie 1 = 1 byte chunk, 8 = 8 byte chunk, etc.
 // usage: var foo = new Chunk(4) // for a 4 byte chunk
-dis.Chunk = function(chunkSize) {
+dis.Chunk = function(chunkSize, isSigned = true) {
 
 	this.data = new Array(chunkSize).fill(0);
 	this.chunkSize = chunkSize;
+	this.isSigned = isSigned;
 
 	dis.Chunk.prototype.initFromBinary = function(inputStream) {
 		for(var i = 0; i < this.chunkSize; i++) {
-			this.data[i] = inputStream.readByte();
+			this.data[i] = this.isSigned ? inputStream.readByte() : inputStream.readUByte();
 		}
 	}
 	dis.Chunk.prototype.encodeToBinary = function(outputStream) {
 		for(var i = 0; i < this.chunkSize; i++) {
-			outputStream.writeByte(this.data[i]);
+			this.isSigned ? outputStream.writeByte(this.data[i]) : outputStream.writeUByte(this.data[i]);
 		}
 	}
 }


### PR DESCRIPTION
This pull request modifies the SignalPdu and IntercomSignalPdu classes to change the signal type from signed int to unsigned int. The Chunk class is also updated to read and write unsigned bytes. It retains default behavior of signed bytes.

This change reflects how the open-dis libraries for c++, c#, and python handle signal pdus as a vector of unsigned int8s.